### PR TITLE
Fixed bug with prod and dev cert URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ target/
 
 # PyCharm
 .idea
+venv

--- a/aioapns/client.py
+++ b/aioapns/client.py
@@ -3,8 +3,8 @@ from aioapns.logging import logger
 
 
 class APNs:
-    def __init__(self, client_cert, max_connections=10, loop=None):
-        self.pool = APNsConnectionPool(client_cert, max_connections, loop)
+    def __init__(self, client_cert, max_connections=10, loop=None, cert_prod=True):
+        self.pool = APNsConnectionPool(client_cert, cert_prod, max_connections, loop)
 
     async def send_notification(self, request):
         response = await self.pool.send_notification(request)


### PR DESCRIPTION
Now client by the default create connection to the prod URL - 'api.push.apple.com' by if you set cert_prod=False - dev URL - 'api.development.push.apple.com'