### PR TITLE
Don't escape UTF-8 characters in the JSON payload.

### DIFF
--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -174,7 +174,7 @@ class APNsBaseClientProtocol(H2Protocol):
             headers=headers
         )
         try:
-            data = json.dumps(request.message).encode()
+            data = json.dumps(request.message, ensure_ascii=False).encode()
             self.conn.send_data(
                 stream_id=stream_id,
                 data=data,


### PR DESCRIPTION
The [APNs documentation] says (under the section for the `alert` field of the payload):

> The JSON \U notation is not supported. Put the actual UTF-8 character in the alert text instead. 

[APNs documentation]: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1

Setting `ensure_ascii=False` has this effect.

I also note that [another APNs library](https://github.com/matrix-org/pushbaby/blob/d3265e32dba12cb25474cb9383481def4a8b3bbe/pushbaby/aps.py#L36)  (granted, for the older protocol) uses this flag, so it seems sane.