### PR TITLE
Stop retrying after MAX_ATTEMPTS and a ConnectionError.

### DIFF
--- a/aioapns/__init__.py
+++ b/aioapns/__init__.py
@@ -1,5 +1,7 @@
 from aioapns.client import APNs
 from aioapns.common import NotificationRequest, PRIORITY_NORMAL, PRIORITY_HIGH
+from aioapns.exceptions import ConnectionError
 
 
-__all__ = ['APNs', 'NotificationRequest', 'PRIORITY_NORMAL', 'PRIORITY_HIGH']
+__all__ = ['APNs', 'NotificationRequest', 'PRIORITY_NORMAL', 'PRIORITY_HIGH',
+           'ConnectionError']


### PR DESCRIPTION
Note that other reasons for retrying (exhausting the № of stream IDs) will not be enough alone to stop retrying.

I think this is what makes the most sense.