### PR TITLE
Add more status codes to APNS_RESPONSE_CODE

### DIFF
--- a/aioapns/common.py
+++ b/aioapns/common.py
@@ -77,3 +77,11 @@ class DynamicBoundedSemaphore(asyncio.BoundedSemaphore):
 
 class APNS_RESPONSE_CODE:
     SUCCESS = '200'
+    BAD_REQUEST = '400'
+    FORBIDDEN = '403'
+    METHOD_NOT_ALLOWED = '405'
+    GONE = '410'
+    PAYLOAD_TOO_LARGE = '413'
+    TOO_MANY_REQUESTS = '429'
+    INTERNAL_SERVER_ERROR = '500'
+    SERVICE_UNAVAILABLE = '503'


### PR DESCRIPTION
This change adds all the possible APNS2 status codes to `APNS_RESPONSE_CODE`. For the names I went with the names as defined in the HTTP protocol, which maps pretty well to what Apple uses.  (I did search for some 'official' constant names, but could not find anything.)