### PR TITLE
ability to pass user-created SSLContext

### DIFF
--- a/aioapns/client.py
+++ b/aioapns/client.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import Optional
+from ssl import SSLContext
 
 from aioapns.connection import APNsCertConnectionPool, APNsKeyConnectionPool
 from aioapns.logging import logger
@@ -18,6 +19,7 @@ class APNs:
         loop: Optional[asyncio.AbstractEventLoop] = None,
         use_sandbox: bool = False,
         no_cert_validation: bool = False,
+        ssl_context: Optional[SSLContext] = None
     ):
 
         if client_cert is not None and key is not None:
@@ -30,7 +32,8 @@ class APNs:
                 max_connection_attempts=max_connection_attempts,
                 loop=loop,
                 use_sandbox=use_sandbox,
-                no_cert_validation=no_cert_validation
+                no_cert_validation=no_cert_validation,
+                ssl_context=ssl_context
             )
         elif all((key, key_id, team_id, topic)):
             self.pool = APNsKeyConnectionPool(
@@ -41,7 +44,8 @@ class APNs:
                 max_connections=max_connections,
                 max_connection_attempts=max_connection_attempts,
                 loop=loop,
-                use_sandbox=use_sandbox
+                use_sandbox=use_sandbox,
+                ssl_context=ssl_context
             )
         else:
             raise ValueError(

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -397,6 +397,7 @@ class APNsCertConnectionPool(APNsBaseConnectionPool):
         loop: Optional[asyncio.AbstractEventLoop] = None,
         use_sandbox: bool = False,
         no_cert_validation: bool = False,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
 
         super(APNsCertConnectionPool, self).__init__(
@@ -408,7 +409,7 @@ class APNsCertConnectionPool(APNsBaseConnectionPool):
         )
 
         self.cert_file = cert_file
-        self.ssl_context = ssl.create_default_context()
+        self.ssl_context = ssl_context or ssl.create_default_context()
         if no_cert_validation:
             self.ssl_context.check_hostname = False
             self.ssl_context.verify_mode = ssl.CERT_NONE
@@ -446,7 +447,8 @@ class APNsKeyConnectionPool(APNsBaseConnectionPool):
                  max_connections: int = 10,
                  max_connection_attempts: Optional[int] = None,
                  loop: Optional[asyncio.AbstractEventLoop] = None,
-                 use_sandbox: bool = False):
+                 use_sandbox: bool = False,
+                 ssl_context: Optional[ssl.SSLContext] = None):
 
         super(APNsKeyConnectionPool, self).__init__(
             topic=topic,
@@ -455,6 +457,8 @@ class APNsKeyConnectionPool(APNsBaseConnectionPool):
             loop=loop,
             use_sandbox=use_sandbox,
         )
+
+        self.ssl_context = ssl_context or ssl.create_default_context()
 
         self.key_id = key_id
         self.team_id = team_id
@@ -478,6 +482,6 @@ class APNsKeyConnectionPool(APNsBaseConnectionPool):
             ),
             host=self.protocol_class.APNS_SERVER,
             port=self.protocol_class.APNS_PORT,
-            ssl=True,
+            ssl=self.ssl_context,
         )
         return protocol


### PR DESCRIPTION
Hi all,

I've faced a SSL issue while trying to send pushes:
```
Could not connect to server: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1124)
Could not send notification c75a6188-7aba-49a6-b8c7-516df28c864b: ConnectionError
```

Investigation showed that this is due to GeoTrust Global CA root certificate that Apple uses for api.push.apple.com have been removed in newer Ubuntu and Debian releases. To work around this I've added the support to pass user-created `SSLContext` object to `APNs` constructor that will be used to connect to APNS. This allows me to construct custom `SSLContext` with provided `cafile` and use it for connecting to Apple like this:

```python
ssl_ctx = ssl.create_default_context(cafile="./apple.pem")

client = aioapns.APNs(
    key="./key.p8",
    key_id=KEY_ID,
    team_id=TEAM_ID,
    topic=BUNDLE_ID,
    use_sandbox=False,
    max_connection_attempts=3,
    ssl_context=ssl_ctx,
)
```

This seems to be a very legitimate feature so I suggest to add in to the upstream.

`ssl_context` argument seems more general than existing `no_cert_validation` because if somebody wants to disable cert validation, she now able to manually construct `SSLContext` with validation disabled. But these two options doesn't conflict, so I've not removed `no_cert_validation` to keep backwards compatibility.