### PR TITLE
fix: limit pyjwt version under 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     install_requires=[
         'h2==3.2.0',
         'pyOpenSSL>=17.5.0',
-        'pyjwt>=1.7.1',
+        'pyjwt>=1.7.1, <2.0.0',
     ]
 )


### PR DESCRIPTION
Hello. 
At first, thank you for developing cool library. I'm using it well :)
And also I am sorry for my poor English 😭 

I found issue #21, and I also had a trouble with pyjwt 2.0.0.

In my opinion, there are two options to fix it.
a) fix the code with using pyjwt 2.0.0 (ex. remove `.decode('ascii')` ) 
b) freeze version.

I think option a is better than b in the long term, but i'm not sure that just removing `.decode` has no side effects.

So finally i decided to freeze version to work well right now, and then next we can do option b.

If someone gives me a guide to check side effect of option b, i'm willing to try it.

Thank you :)
