### PR TITLE
send_notification now takes a function that is called on error.

### DIFF
--- a/aioapns/client.py
+++ b/aioapns/client.py
@@ -53,9 +53,12 @@ class APNs:
                 "the key credentials"
             )
 
-    async def send_notification(self, request):
+    async def send_notification(self, request, error_func=None):
         response = await self.pool.send_notification(request)
         if not response.is_successful:
+            if error_func:
+                await error_func(request.notification_id,
+                                 response, device_token=request.device_token)
             logger.error(
                 "Status of notification %s is %s (%s)",
                 request.notification_id,


### PR DESCRIPTION
You can now pass a function as `error_func` that will get called when `send_notification` fails.


Example:
```
async def error_func(notification_id, response, device_token=device_token):
        await mark_tokens_as_invalid(device_token)
        return print(
            f'deregistering {device_token}')

await apns_client.send_notification(request, error_func=error_func)
```