### PR TITLE
Limit number of failed attempts, provide more details about 

### DIFF
--- a/aioapns/client.py
+++ b/aioapns/client.py
@@ -15,7 +15,7 @@ class APNs:
         team_id: Optional[str] = None,
         topic: Optional[str] = None,
         max_connections: int = 10,
-        max_connection_attempts: Optional[int] = None,
+        max_connection_attempts: int = 5,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         use_sandbox: bool = False,
         no_cert_validation: bool = False,

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -25,7 +25,11 @@ from aioapns.common import (
     DynamicBoundedSemaphore,
     NotificationResult,
 )
-from aioapns.exceptions import ConnectionClosed, ConnectionError, MaxAttemptsExceeded
+from aioapns.exceptions import (
+    ConnectionClosed,
+    ConnectionError,
+    MaxAttemptsExceeded,
+)
 from aioapns.logging import logger
 
 

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -223,7 +223,7 @@ class APNsBaseClientProtocol(H2Protocol):
         raise NotImplementedError
 
     def connection_lost(self, exc):
-        logger.debug("Connection %s lost!", self)
+        logger.debug("Connection %s lost! Error: %s", self, exc)
 
         if self.inactivity_timer:
             self.inactivity_timer.cancel()
@@ -231,7 +231,7 @@ class APNsBaseClientProtocol(H2Protocol):
         if self.on_connection_lost:
             self.on_connection_lost(self)
 
-        closed_connection = ConnectionClosed()
+        closed_connection = ConnectionClosed(str(exc))
         for request in self.requests.values():
             request.set_exception(closed_connection)
         self.free_channels.destroy(closed_connection)

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -407,7 +407,6 @@ class APNsBaseConnectionPool:
                     "Could not send notification %s: " "ConnectionClosed",
                     request.notification_id,
                 )
-                raise
             except FlowControlError:
                 logger.debug(
                     "Got FlowControlError for notification %s",

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -376,8 +376,9 @@ class APNsBaseConnectionPool:
                             return connection
 
     async def send_notification(self, request):
-        failed_attempts = 0
-        while failed_attempts < self.max_connection_attempts:
+        attempts = 0
+        while attempts < self.max_connection_attempts:
+            attempts += 1
             logger.debug(
                 "Notification %s: waiting for connection",
                 request.notification_id,
@@ -385,7 +386,6 @@ class APNsBaseConnectionPool:
             try:
                 connection = await self.acquire()
             except ConnectionError:
-                failed_attempts += 1
                 logger.warning(
                     "Could not send notification %s: " "ConnectionError",
                     request.notification_id,
@@ -414,9 +414,8 @@ class APNsBaseConnectionPool:
                     request.notification_id,
                 )
                 await asyncio.sleep(1)
-            failed_attempts += 1
         logger.error(
-            "Failed to send after %d attempts.", failed_attempts
+            "Failed to send after %d attempts.", attempts
         )
         raise MaxAttemptsExceeded
 

--- a/aioapns/exceptions.py
+++ b/aioapns/exceptions.py
@@ -4,3 +4,7 @@ class ConnectionClosed(Exception):
 
 class ConnectionError(Exception):
     pass
+
+
+class MaxAttemptsExceeded(Exception):
+    pass


### PR DESCRIPTION
Not sure this is the best way to deal with this, but just some points to adjust behaviour:

- Provide more detailed description when connection is closed. Usually it could be `SSLV3_ALERT_CERTIFICATE_EXPIRED` and it's very helpful to clearly understand an initial error.
- Set default value for `max_connection_attempts`.
- Use `max_connection_attempts` to count all attempts in `send_notification`, even if it's not a "connection" error – IMO it doesn't matter to the end user in which part of sending process error was raised.
- Don't use infinite loop, I think nobody wants to have 100000 failed attempts in their production.