### PR TITLE
Ensure "typ" JWT header is not used

### DIFF
--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -75,7 +75,7 @@ class JWTAuthorizationHeaderProvider(AuthorizationHeaderProvider):
                 payload={"iss": self.team_id, "iat": self.__issued_at},
                 key=self.key,
                 algorithm="ES256",
-                headers={"kid": self.key_id},
+                headers={"kid": self.key_id, "typ": None},
             )
             self.__header = f"bearer {token}"
         return self.__header


### PR DESCRIPTION
Tokens with "typ" headers are rejected by Apple servers. But PyJWT is now adding the header by default.



JWT tokens can be checked for validity with this tool:
https://icloud.developer.apple.com/dashboard/notifications/

![image](https://github.com/Fatal1ty/aioapns/assets/429169/0df35724-06b0-4a63-a7e1-60b51e46280b)
![image](https://github.com/Fatal1ty/aioapns/assets/429169/775ab35e-c097-4450-845c-93c630ab204c)


