### PR TITLE
Add support for timestamp

### DIFF
--- a/aioapns/common.py
+++ b/aioapns/common.py
@@ -1,5 +1,4 @@
 import asyncio
-from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import uuid4
@@ -56,7 +55,7 @@ class NotificationResult:
         notification_id: str,
         status: str,
         description: Optional[str] = None,
-        timestamp: Optional[datetime] = None
+        timestamp: Optional[int] = None
     ):
         self.notification_id = notification_id
         self.status = status

--- a/aioapns/common.py
+++ b/aioapns/common.py
@@ -55,7 +55,7 @@ class NotificationResult:
         notification_id: str,
         status: str,
         description: Optional[str] = None,
-        timestamp: Optional[int] = None
+        timestamp: Optional[int] = None,
     ):
         self.notification_id = notification_id
         self.status = status

--- a/aioapns/common.py
+++ b/aioapns/common.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import uuid4
@@ -48,17 +49,19 @@ class NotificationRequest:
 
 
 class NotificationResult:
-    __slots__ = ("notification_id", "status", "description")
+    __slots__ = ("notification_id", "status", "description", "timestamp")
 
     def __init__(
         self,
         notification_id: str,
         status: str,
         description: Optional[str] = None,
+        timestamp: Optional[datetime] = None
     ):
         self.notification_id = notification_id
         self.status = status
         self.description = description
+        self.timestamp = timestamp
 
     @property
     def is_successful(self) -> bool:

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import ssl
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Type
 
@@ -267,14 +267,14 @@ class APNsBaseClientProtocol(H2Protocol):
     def on_data_received(self, raw_data: bytes, stream_id: int) -> None:
         data = json.loads(raw_data.decode())
         reason = data.get("reason", "")
-        timestamp = data.get("timestamp", None)
+        timestamp = data.get("timestamp")
         if timestamp:
             try:
                 # According to the docs "timestamp" is
                 # "represented in milliseconds since Epoch"
                 # so we divide by 1000.0 to get the POSIX
                 # time (seconds) but still keep precision
-                timestamp = datetime.fromtimestamp(int(timestamp) / 1000.0)
+                timestamp = datetime.fromtimestamp(timestamp / 1000.0, timezone.utc)
             except Exception:
                 timestamp = None
 

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import ssl
 import time
+from datetime import datetime
 from functools import partial
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Type
 
@@ -266,6 +267,16 @@ class APNsBaseClientProtocol(H2Protocol):
     def on_data_received(self, raw_data: bytes, stream_id: int) -> None:
         data = json.loads(raw_data.decode())
         reason = data.get("reason", "")
+        timestamp = data.get("timestamp", None)
+        if timestamp:
+            try:
+                # According to the docs "timestamp" is "represented in milliseconds since Epoch"
+                # so we divide by 1000.0 to get the POSIX time (seconds) but still keep precision
+                # Docs: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns#3394529
+                timestamp = datetime.fromtimestamp(int(timestamp) / 1000.0)
+            except Exception:
+                timestamp = None
+
         if not reason:
             return
 
@@ -276,7 +287,7 @@ class APNsBaseClientProtocol(H2Protocol):
                 # TODO: Теоретически здесь может быть ошибка, если нет ключа
                 status = self.request_statuses.pop(notification_id)
                 result = NotificationResult(
-                    notification_id, status, description=reason
+                    notification_id, status, description=reason, timestamp=timestamp
                 )
                 request.set_result(result)
             else:

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import ssl
 import time
-from datetime import datetime, timezone
 from functools import partial
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Type
 
@@ -268,15 +267,6 @@ class APNsBaseClientProtocol(H2Protocol):
         data = json.loads(raw_data.decode())
         reason = data.get("reason", "")
         timestamp = data.get("timestamp")
-        if timestamp:
-            try:
-                # According to the docs "timestamp" is
-                # "represented in milliseconds since Epoch"
-                # so we divide by 1000.0 to get the POSIX
-                # time (seconds) but still keep precision
-                timestamp = datetime.fromtimestamp(timestamp / 1000.0, timezone.utc)
-            except Exception:
-                timestamp = None
 
         if not reason:
             return

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -270,9 +270,10 @@ class APNsBaseClientProtocol(H2Protocol):
         timestamp = data.get("timestamp", None)
         if timestamp:
             try:
-                # According to the docs "timestamp" is "represented in milliseconds since Epoch"
-                # so we divide by 1000.0 to get the POSIX time (seconds) but still keep precision
-                # Docs: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns#3394529
+                # According to the docs "timestamp" is
+                # "represented in milliseconds since Epoch"
+                # so we divide by 1000.0 to get the POSIX
+                # time (seconds) but still keep precision
                 timestamp = datetime.fromtimestamp(int(timestamp) / 1000.0)
             except Exception:
                 timestamp = None
@@ -287,7 +288,10 @@ class APNsBaseClientProtocol(H2Protocol):
                 # TODO: Теоретически здесь может быть ошибка, если нет ключа
                 status = self.request_statuses.pop(notification_id)
                 result = NotificationResult(
-                    notification_id, status, description=reason, timestamp=timestamp
+                    notification_id,
+                    status,
+                    description=reason,
+                    timestamp=timestamp,
                 )
                 request.set_result(result)
             else:


### PR DESCRIPTION
Resolves #46 

- Adds optional `datetime` property `timestamp` to `NotificationResult`.
- Checks for the `timestamp` property in the response data and if it’s found converts it to a `datetime` and passes it to `NotificationResult`