### PR TITLE
Remove isinstance check to work with uvloop transports

### DIFF
--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -88,8 +88,7 @@ class H2Protocol(asyncio.Protocol):
         self.free_channels = ChannelPool(1000)
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
-        assert isinstance(transport, asyncio.Transport)
-        self.transport = transport
+        self.transport = transport  # type: ignore
         self.conn.initiate_connection()
         self.flush()
 


### PR DESCRIPTION
Remove `assert isinstance(transport, asyncio.Transport)` in `connection_made` that was introduced to satisfy static type checkers. At runtime this transport can come from uvloop without `asyncio.Transport` in parents. Related PR:
* https://github.com/Fatal1ty/aioapns/pull/56