### PR TITLE
fix apns_protocol_factory being wrapped in tuple

### DIFF
--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -557,14 +557,12 @@ class APNsKeyConnectionPool(APNsBaseConnectionPool):
         auth_provider = JWTAuthorizationHeaderProvider(
             key=self.key, key_id=self.key_id, team_id=self.team_id
         )
-        apns_protocol_factory = (
-            partial(
-                self.protocol_class,
-                self.apns_topic,
-                self.loop,
-                self.discard_connection,
-                auth_provider,
-            ),
+        apns_protocol_factory = partial(
+            self.protocol_class,
+            self.apns_topic,
+            self.loop,
+            self.discard_connection,
+            auth_provider,
         )
 
         if self.proxy_host and self.proxy_port:


### PR DESCRIPTION
PR should fix mistake where `apns_protocol_factory` is wrapped in tuple. It crashes `APNsKeyConnectionPool._create_connection()` and manifests itself in pretty unclear way.

```
...
ERROR 2024-07-02 11:57:47,628 connection aioapns 22419 6191968256 Could not connect to server: 'tuple' object is not callable
WARNING 2024-07-02 11:57:47,629 connection aioapns 22419 6191968256 Could not send notification a5dc24f9-946c-488a-bd4f-e408049831cb: ConnectionError
ERROR 2024-07-02 11:57:48,631 connection aioapns 22419 6191968256 Failed to send after 5 attempts.
```