### PR TITLE
Added a new parameter to be able to use the port 2197 when sending APNs notifications through a firewall

### DIFF
--- a/aioapns/client.py
+++ b/aioapns/client.py
@@ -30,6 +30,7 @@ class APNs:
                 [NotificationRequest, NotificationResult], Awaitable[None]
             ]
         ] = None,
+        use_alternative_port: bool = False,
     ) -> None:
         self.pool: APNsBaseConnectionPool
         self.err_func = err_func
@@ -46,6 +47,7 @@ class APNs:
                 ssl_context=ssl_context,
                 proxy_host=proxy_host,
                 proxy_port=proxy_port,
+                use_alternative_port=use_alternative_port,
             )
         elif key and key_id and team_id and topic:
             self.pool = APNsKeyConnectionPool(
@@ -59,6 +61,7 @@ class APNs:
                 ssl_context=ssl_context,
                 proxy_host=proxy_host,
                 proxy_port=proxy_port,
+                use_alternative_port=use_alternative_port,
             )
         else:
             raise ValueError(

--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -331,6 +331,7 @@ class APNsBaseConnectionPool:
         use_sandbox: bool = False,
         proxy_host: Optional[str] = None,
         proxy_port: Optional[int] = None,
+        use_alternative_port: bool = False,
     ) -> None:
         self.apns_topic = topic
         self.max_connections = max_connections
@@ -339,6 +340,9 @@ class APNsBaseConnectionPool:
             self.protocol_class = APNsDevelopmentClientProtocol
         else:
             self.protocol_class = APNsProductionClientProtocol
+        if use_alternative_port:
+            # The same alternative port adopted by apns2
+            self.protocol_class.APNS_PORT = 2197
 
         self.loop = asyncio.get_event_loop()
         self.connections: List[APNsBaseClientProtocol] = []
@@ -535,6 +539,7 @@ class APNsKeyConnectionPool(APNsBaseConnectionPool):
         ssl_context: Optional[ssl.SSLContext] = None,
         proxy_host: Optional[str] = None,
         proxy_port: Optional[int] = None,
+        use_alternative_port: bool = False,
     ) -> None:
         super(APNsKeyConnectionPool, self).__init__(
             topic=topic,
@@ -543,6 +548,7 @@ class APNsKeyConnectionPool(APNsBaseConnectionPool):
             use_sandbox=use_sandbox,
             proxy_host=proxy_host,
             proxy_port=proxy_port,
+            use_alternative_port=use_alternative_port,
         )
 
         self.ssl_context = ssl_context or ssl.create_default_context()


### PR DESCRIPTION
This change add a new parameter, called use_alternative_port, that when is True, it will use the alternative port (2197) to send APNs notifications.

If you use a firewall or private [Access Point Name](https://support.apple.com/kb/HT201699) for cellular data, your Apple devices must be able to connect to specific ports on specific hosts:

- TCP port 5223 to communicate with APNs.
- TCP port 443 or 2197 to send notifications to APNs.

TCP port 443 is used during device activation, and afterwards for fallback if devices can't reach APNs on port 5223. The connection on port 443 uses a proxy as long as the proxy allows the communication to pass through without decrypting.

(ref. https://support.apple.com/en-us/102266)