### PR TITLE
Sleep for all exceptions before retrying

### DIFF
--- a/aioapns/connection.py
+++ b/aioapns/connection.py
@@ -434,7 +434,7 @@ class APNsBaseConnectionPool:
                     "Got FlowControlError for notification %s",
                     request.notification_id,
                 )
-                await asyncio.sleep(1)
+            await asyncio.sleep(1)
         logger.error("Failed to send after %d attempts.", attempts)
         raise MaxAttemptsExceeded
 


### PR DESCRIPTION
Dedent the retry sleep so it runs after any exception in the send loop, not just `FlowControlError` — previously `NoAvailableStreamIDError` and `ConnectionClosed` retried immediately with no backoff at all.